### PR TITLE
Add an example of map's style

### DIFF
--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -10,4 +10,5 @@ members = [
   "leptos-simple",
   "custom-icons-with-markers",
   "draggable-marker",
+  "change-map-style",
 ]

--- a/examples/change-map-style/.gitignore
+++ b/examples/change-map-style/.gitignore
@@ -1,0 +1,4 @@
+/target
+/dist
+/app
+/node_modules

--- a/examples/change-map-style/Cargo.toml
+++ b/examples/change-map-style/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "change-map-style"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+yew = { version = "0.20", features = ["csr"] }
+mapboxgl = { path = "../../" }
+log = "0.4.6"
+wasm-logger = "0.2.0"
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+futures = "0.3"
+web-sys = { version = "0.3", features = ["console"] }
+geojson = "0.24"

--- a/examples/change-map-style/README.md
+++ b/examples/change-map-style/README.md
@@ -1,0 +1,13 @@
+## [Change a map's style](https://docs.mapbox.com/mapbox-gl-js/example/setstyle/) with Mapbox-gl-rs
+
+* Run app
+```
+trunk serve
+```
+
+* If you have a [Mapbox token](https://account.mapbox.com/access-tokens), specify when building
+```
+MAPBOX_TOKEN={YOUR_TOKEN} trunk serve
+```
+
+Open http://localhost:8080 in your browser

--- a/examples/change-map-style/index.html
+++ b/examples/change-map-style/index.html
@@ -1,0 +1,24 @@
+<html>
+
+<head>
+    <meta charset="utf-8" />
+    <title>App</title>
+    <link href='https://api.mapbox.com/mapbox-gl-js/v2.10.0/mapbox-gl.css' rel='stylesheet' />
+    <script src="https://api.mapbox.com/mapbox-gl-js/v2.10.0/mapbox-gl.js"></script>
+    <style>
+        body { margin: 0; padding: 0; }
+        #map { position: absolute; top: 0; bottom: 0; width: 100%; }
+        #menu {
+            position: absolute;
+            background: #efefef;
+            padding: 10px;
+            font-family: 'Open Sans', sans-serif;
+        }
+
+    </style>
+</head>
+
+<body>
+</body>
+
+</html>

--- a/examples/change-map-style/src/main.rs
+++ b/examples/change-map-style/src/main.rs
@@ -1,0 +1,95 @@
+use futures::channel::oneshot;
+use log::info;
+use mapboxgl::{event, LngLat, Map, MapEventListener, MapFactory, MapOptions, StyleOptions};
+use std::{cell::RefCell, rc::Rc};
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+use yew::{use_effect_with_deps, use_mut_ref};
+
+struct Listener {
+    tx: Option<oneshot::Sender<()>>,
+}
+
+impl MapEventListener for Listener {
+    fn on_load(&mut self, _map: Rc<Map>, _e: event::MapBaseEvent) {
+        self.tx.take().unwrap().send(()).unwrap();
+    }
+}
+
+#[hook]
+fn use_map() -> Rc<RefCell<Option<MapFactory>>> {
+    let map = use_mut_ref(|| Option::<MapFactory>::None);
+
+    {
+        let map = map.clone();
+        use_effect_with_deps(
+            move |_| {
+                let mut m = create_map();
+                let (tx, rx) = oneshot::channel();
+                m.set_listener(Listener { tx: Some(tx) });
+
+                wasm_bindgen_futures::spawn_local(async move {
+                    rx.await.unwrap();
+                    if let Ok(mut map) = map.try_borrow_mut() {
+                        info!("map loaded");
+                        map.replace(m);
+                    } else {
+                        log::error!("Failed to create Map");
+                    }
+                });
+                || {}
+            },
+            (),
+        );
+    }
+    map
+}
+
+pub fn create_map() -> MapFactory {
+    let token = std::env!("MAPBOX_TOKEN");
+
+    let opts = MapOptions::new(token.into(), "map".into())
+        .center(LngLat::new(-2.81361, 36.77271))
+        .zoom(13.0)
+        .style("mapbox://styles/mapbox/satellite-streets-v12".into());
+    mapboxgl::MapFactory::new(opts).unwrap()
+}
+
+#[function_component(App)]
+fn app() -> Html {
+    let map = use_map();
+    let on_click = {
+        Callback::from(move |e: Event| {
+            let value = e.target_dyn_into::<HtmlInputElement>().unwrap().value();
+            let style = format!("mapbox://styles/mapbox/{}", value);
+            map.borrow_mut()
+                .as_ref()
+                .unwrap()
+                .map
+                .set_style(style, StyleOptions::new());
+        })
+    };
+
+    html! {
+        <>
+            <div id="map" style="width: 100vw; height: 100vh;"></div>
+            <div id="menu">
+                <input id="satellite-streets-v12" type="radio" name="rtoggle" value="satellite-streets-v12" onchange={on_click.clone()} checked=true />
+                <label for="satellite-streets-v12">{"satellite streets"}</label>
+                <input id="light-v11" type="radio" name="rtoggle" value="light-v11" onchange={on_click.clone()} />
+                <label for="light-v11">{"light"}</label>
+                <input id="dark-v11" type="radio" name="rtoggle" value="dark-v11" onchange={on_click.clone()} />
+                <label for="dark-v11">{"dark"}</label>
+                <input id="streets-v12" type="radio" name="rtoggle" value="streets-v12" onchange={on_click.clone()} />
+                <label for="streets-v12">{"streets"}</label>
+                <input id="outdoors-v12" type="radio" name="rtoggle" value="outdoors-v12" onchange={on_click.clone()} />
+                <label for="outdoors-v12">{"outdoors"}</label>
+            </div>
+        </>
+    }
+}
+
+fn main() {
+    wasm_logger::init(wasm_logger::Config::default());
+    yew::Renderer::<App>::new().render();
+}

--- a/src/js.rs
+++ b/src/js.rs
@@ -114,6 +114,9 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn isRotating(this: &Map) -> bool;
 
+    #[wasm_bindgen(method)]
+    pub fn setStyle(this: &Map, style: String, options: JsValue) -> bool;
+
     // Images
 
     /// Add image resource.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod layer;
 pub mod marker;
 pub mod popup;
 pub mod source;
+pub mod style;
 
 use anyhow::Result;
 use enclose::enclose;
@@ -31,6 +32,7 @@ pub use layer::{Layer, Layout, LayoutProperty};
 pub use marker::{Marker, MarkerEventListener, MarkerOptions};
 pub use popup::{Popup, PopupOptions};
 pub use source::GeoJsonSource;
+pub use style::StyleOptions;
 
 const DEFAULT_STYLE: &str = "mapbox://styles/mapbox/streets-v11";
 
@@ -696,6 +698,13 @@ impl Map {
         let handler::BoxZoomHandler { inner } = handler;
         self.inner
             .set_handler(&HandlerType::BoxZoom.to_string(), inner);
+    }
+
+    pub fn set_style(&self, style: impl Into<String>, options: crate::style::StyleOptions) {
+        self.inner.setStyle(
+            style.into(),
+            serde_wasm_bindgen::to_value(&options).unwrap(),
+        );
     }
 
     /// Add image resource.

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,0 +1,16 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct StyleOptions {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diff: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_ideograph_font_family: Option<String>,
+}
+
+impl StyleOptions {
+    pub fn new() -> StyleOptions {
+        StyleOptions::default()
+    }
+}


### PR DESCRIPTION
#### Related issue  
#32 

#### What does this PR do?
- A call function to [`set_style`](https://docs.mapbox.com/mapbox-gl-js/api/map/#map#setstyle) was needed, so added it.
- added example of map's style