### PR TITLE
Remove MapFactory and move functionalities to Map

### DIFF
--- a/examples/add-image/Trunk.toml
+++ b/examples/add-image/Trunk.toml
@@ -1,0 +1,45 @@
+# An example Trunk.toml with all possible fields along with their defaults.
+
+[build]
+# The index HTML file to drive the bundling process.
+target = "index.html"
+# Build in release mode.
+release = false
+# The output dir for all final assets.
+dist = "dist"
+# The public URL from which assets are to be served.
+public_url = "/"
+# Whether to include hash values in the output file names.
+filehash = true
+
+[watch]
+# Paths to watch. The `build.target`'s parent folder is watched by default.
+watch = []
+# Paths to ignore.
+ignore = []
+
+[serve]
+# The address to serve on.
+address = "127.0.0.1"
+# The port to serve on.
+port = 8080
+# Open a browser tab once the initial build is complete.
+open = false
+# Disable auto-reload of the web app.
+no_autoreload = false
+
+[clean]
+# The output dir for all final assets.
+dist = "dist"
+# Optionally perform a cargo clean.
+cargo = false
+
+[tools]
+# Default dart-sass version to download.
+sass = "1.54.9"
+# Default wasm-bindgen version to download.
+wasm_bindgen = "0.2.87"
+# Default wasm-opt version to download.
+wasm_opt = "version_110"
+# Default tailwindcss-cli version to download.
+tailwindcss = "3.3.2"

--- a/examples/change-map-style/Trunk.toml
+++ b/examples/change-map-style/Trunk.toml
@@ -1,0 +1,45 @@
+# An example Trunk.toml with all possible fields along with their defaults.
+
+[build]
+# The index HTML file to drive the bundling process.
+target = "index.html"
+# Build in release mode.
+release = false
+# The output dir for all final assets.
+dist = "dist"
+# The public URL from which assets are to be served.
+public_url = "/"
+# Whether to include hash values in the output file names.
+filehash = true
+
+[watch]
+# Paths to watch. The `build.target`'s parent folder is watched by default.
+watch = []
+# Paths to ignore.
+ignore = []
+
+[serve]
+# The address to serve on.
+address = "127.0.0.1"
+# The port to serve on.
+port = 8080
+# Open a browser tab once the initial build is complete.
+open = false
+# Disable auto-reload of the web app.
+no_autoreload = false
+
+[clean]
+# The output dir for all final assets.
+dist = "dist"
+# Optionally perform a cargo clean.
+cargo = false
+
+[tools]
+# Default dart-sass version to download.
+sass = "1.54.9"
+# Default wasm-bindgen version to download.
+wasm_bindgen = "0.2.87"
+# Default wasm-opt version to download.
+wasm_opt = "version_110"
+# Default tailwindcss-cli version to download.
+tailwindcss = "3.3.2"

--- a/examples/custom-icons-with-markers/Trunk.toml
+++ b/examples/custom-icons-with-markers/Trunk.toml
@@ -1,0 +1,45 @@
+# An example Trunk.toml with all possible fields along with their defaults.
+
+[build]
+# The index HTML file to drive the bundling process.
+target = "index.html"
+# Build in release mode.
+release = false
+# The output dir for all final assets.
+dist = "dist"
+# The public URL from which assets are to be served.
+public_url = "/"
+# Whether to include hash values in the output file names.
+filehash = true
+
+[watch]
+# Paths to watch. The `build.target`'s parent folder is watched by default.
+watch = []
+# Paths to ignore.
+ignore = []
+
+[serve]
+# The address to serve on.
+address = "127.0.0.1"
+# The port to serve on.
+port = 8080
+# Open a browser tab once the initial build is complete.
+open = false
+# Disable auto-reload of the web app.
+no_autoreload = false
+
+[clean]
+# The output dir for all final assets.
+dist = "dist"
+# Optionally perform a cargo clean.
+cargo = false
+
+[tools]
+# Default dart-sass version to download.
+sass = "1.54.9"
+# Default wasm-bindgen version to download.
+wasm_bindgen = "0.2.87"
+# Default wasm-opt version to download.
+wasm_opt = "version_110"
+# Default tailwindcss-cli version to download.
+tailwindcss = "3.3.2"

--- a/examples/custom-icons-with-markers/src/main.rs
+++ b/examples/custom-icons-with-markers/src/main.rs
@@ -1,5 +1,5 @@
 use geojson::GeoJson;
-use mapboxgl::{LngLat, MapFactory, MapOptions, Marker, MarkerOptions};
+use mapboxgl::{LngLat, Map, MapOptions, Marker, MarkerOptions};
 use std::str::FromStr;
 use std::{cell::RefCell, rc::Rc};
 use wasm_bindgen::JsCast;
@@ -8,13 +8,13 @@ use yew::prelude::*;
 use yew::{use_effect_with_deps, use_mut_ref};
 
 #[hook]
-fn use_map(geojson: GeoJson) -> Rc<RefCell<Option<MapFactory>>> {
-    let map = use_mut_ref(|| Option::<MapFactory>::None);
+fn use_map(geojson: GeoJson) -> Rc<RefCell<Option<Rc<Map>>>> {
+    let map = use_mut_ref(|| Option::<Rc<Map>>::None);
 
     {
         use_effect_with_deps(
             move |_| {
-                let mut m = create_map();
+                let m = create_map();
 
                 // create a marker element for each feature
                 let geo_value = geojson.to_json_value();
@@ -67,7 +67,7 @@ fn use_map(geojson: GeoJson) -> Rc<RefCell<Option<MapFactory>>> {
     map
 }
 
-pub fn create_map() -> MapFactory {
+pub fn create_map() -> Rc<Map> {
     let token = std::env!("MAPBOX_TOKEN");
 
     let opts = MapOptions::new(token.into(), "map".into())
@@ -75,7 +75,7 @@ pub fn create_map() -> MapFactory {
         .zoom(5.0)
         .style("mapbox://styles/mapbox/streets-v12".into());
 
-    mapboxgl::MapFactory::new(opts).unwrap()
+    Map::new(opts).unwrap()
 }
 
 #[function_component(App)]

--- a/examples/draggable-marker/Trunk.toml
+++ b/examples/draggable-marker/Trunk.toml
@@ -1,0 +1,45 @@
+# An example Trunk.toml with all possible fields along with their defaults.
+
+[build]
+# The index HTML file to drive the bundling process.
+target = "index.html"
+# Build in release mode.
+release = false
+# The output dir for all final assets.
+dist = "dist"
+# The public URL from which assets are to be served.
+public_url = "/"
+# Whether to include hash values in the output file names.
+filehash = true
+
+[watch]
+# Paths to watch. The `build.target`'s parent folder is watched by default.
+watch = []
+# Paths to ignore.
+ignore = []
+
+[serve]
+# The address to serve on.
+address = "127.0.0.1"
+# The port to serve on.
+port = 8080
+# Open a browser tab once the initial build is complete.
+open = false
+# Disable auto-reload of the web app.
+no_autoreload = false
+
+[clean]
+# The output dir for all final assets.
+dist = "dist"
+# Optionally perform a cargo clean.
+cargo = false
+
+[tools]
+# Default dart-sass version to download.
+sass = "1.54.9"
+# Default wasm-bindgen version to download.
+wasm_bindgen = "0.2.87"
+# Default wasm-opt version to download.
+wasm_opt = "version_110"
+# Default tailwindcss-cli version to download.
+tailwindcss = "3.3.2"

--- a/examples/geojson-source/Trunk.toml
+++ b/examples/geojson-source/Trunk.toml
@@ -1,0 +1,45 @@
+# An example Trunk.toml with all possible fields along with their defaults.
+
+[build]
+# The index HTML file to drive the bundling process.
+target = "index.html"
+# Build in release mode.
+release = false
+# The output dir for all final assets.
+dist = "dist"
+# The public URL from which assets are to be served.
+public_url = "/"
+# Whether to include hash values in the output file names.
+filehash = true
+
+[watch]
+# Paths to watch. The `build.target`'s parent folder is watched by default.
+watch = []
+# Paths to ignore.
+ignore = []
+
+[serve]
+# The address to serve on.
+address = "127.0.0.1"
+# The port to serve on.
+port = 8080
+# Open a browser tab once the initial build is complete.
+open = false
+# Disable auto-reload of the web app.
+no_autoreload = false
+
+[clean]
+# The output dir for all final assets.
+dist = "dist"
+# Optionally perform a cargo clean.
+cargo = false
+
+[tools]
+# Default dart-sass version to download.
+sass = "1.54.9"
+# Default wasm-bindgen version to download.
+wasm_bindgen = "0.2.87"
+# Default wasm-opt version to download.
+wasm_opt = "version_110"
+# Default tailwindcss-cli version to download.
+tailwindcss = "3.3.2"

--- a/examples/geojson-source/src/main.rs
+++ b/examples/geojson-source/src/main.rs
@@ -1,6 +1,6 @@
 use futures::channel::oneshot;
 use log::*;
-use mapboxgl::{event, layer, Layer, LngLat, Map, MapEventListener, MapFactory, MapOptions};
+use mapboxgl::{event, layer, Layer, LngLat, Map, MapEventListener, MapOptions};
 use std::{cell::RefCell, rc::Rc};
 use yew::prelude::*;
 use yew::{use_effect_with_deps, use_mut_ref};
@@ -69,17 +69,17 @@ impl MapEventListener for Listener {
 }
 
 #[hook]
-fn use_map() -> Rc<RefCell<Option<MapFactory>>> {
-    let map = use_mut_ref(|| Option::<MapFactory>::None);
+fn use_map() -> Rc<RefCell<Option<Rc<Map>>>> {
+    let map = use_mut_ref(|| Option::<Rc<Map>>::None);
 
     {
         let map = map.clone();
         use_effect_with_deps(
             move |_| {
-                let mut m = create_map();
+                let m = create_map();
 
                 let (tx, rx) = oneshot::channel();
-                m.set_listener(Listener { tx: Some(tx) });
+                let _ = m.on(Listener { tx: Some(tx) }).unwrap();
 
                 wasm_bindgen_futures::spawn_local(async move {
                     rx.await.unwrap();
@@ -108,14 +108,14 @@ fn app() -> Html {
     }
 }
 
-pub fn create_map() -> MapFactory {
+pub fn create_map() -> Rc<Map> {
     let token = std::env!("MAPBOX_TOKEN");
 
     let opts = MapOptions::new(token.into(), "map".into())
         .center(LngLat::new(-122.486052, 37.830348))
         .zoom(15.0);
 
-    mapboxgl::MapFactory::new(opts).unwrap()
+    Map::new(opts).unwrap()
 }
 
 fn main() {

--- a/examples/leptos-simple/Trunk.toml
+++ b/examples/leptos-simple/Trunk.toml
@@ -1,0 +1,45 @@
+# An example Trunk.toml with all possible fields along with their defaults.
+
+[build]
+# The index HTML file to drive the bundling process.
+target = "index.html"
+# Build in release mode.
+release = false
+# The output dir for all final assets.
+dist = "dist"
+# The public URL from which assets are to be served.
+public_url = "/"
+# Whether to include hash values in the output file names.
+filehash = true
+
+[watch]
+# Paths to watch. The `build.target`'s parent folder is watched by default.
+watch = []
+# Paths to ignore.
+ignore = []
+
+[serve]
+# The address to serve on.
+address = "127.0.0.1"
+# The port to serve on.
+port = 8080
+# Open a browser tab once the initial build is complete.
+open = false
+# Disable auto-reload of the web app.
+no_autoreload = false
+
+[clean]
+# The output dir for all final assets.
+dist = "dist"
+# Optionally perform a cargo clean.
+cargo = false
+
+[tools]
+# Default dart-sass version to download.
+sass = "1.54.9"
+# Default wasm-bindgen version to download.
+wasm_bindgen = "0.2.87"
+# Default wasm-opt version to download.
+wasm_opt = "version_110"
+# Default tailwindcss-cli version to download.
+tailwindcss = "3.3.2"

--- a/examples/leptos-simple/src/main.rs
+++ b/examples/leptos-simple/src/main.rs
@@ -1,10 +1,10 @@
 use leptos::*;
-use mapboxgl::{LngLat, MapFactory, MapOptions};
+use mapboxgl::{LngLat, Map, MapOptions};
 
 fn main() {
     let token = std::env!("MAPBOX_TOKEN");
     mount_to_body(|cx| view! { cx,  <Map/> });
-    let _map = MapFactory::new(
+    let _map = Map::new(
         MapOptions::new(token.into(), "map".into())
             .center(LngLat::new(139.7647863, 35.6812373))
             .zoom(15.0),

--- a/examples/on-load/Trunk.toml
+++ b/examples/on-load/Trunk.toml
@@ -1,0 +1,45 @@
+# An example Trunk.toml with all possible fields along with their defaults.
+
+[build]
+# The index HTML file to drive the bundling process.
+target = "index.html"
+# Build in release mode.
+release = false
+# The output dir for all final assets.
+dist = "dist"
+# The public URL from which assets are to be served.
+public_url = "/"
+# Whether to include hash values in the output file names.
+filehash = true
+
+[watch]
+# Paths to watch. The `build.target`'s parent folder is watched by default.
+watch = []
+# Paths to ignore.
+ignore = []
+
+[serve]
+# The address to serve on.
+address = "127.0.0.1"
+# The port to serve on.
+port = 8080
+# Open a browser tab once the initial build is complete.
+open = false
+# Disable auto-reload of the web app.
+no_autoreload = false
+
+[clean]
+# The output dir for all final assets.
+dist = "dist"
+# Optionally perform a cargo clean.
+cargo = false
+
+[tools]
+# Default dart-sass version to download.
+sass = "1.54.9"
+# Default wasm-bindgen version to download.
+wasm_bindgen = "0.2.87"
+# Default wasm-opt version to download.
+wasm_opt = "version_110"
+# Default tailwindcss-cli version to download.
+tailwindcss = "3.3.2"

--- a/examples/popup/Trunk.toml
+++ b/examples/popup/Trunk.toml
@@ -1,0 +1,45 @@
+# An example Trunk.toml with all possible fields along with their defaults.
+
+[build]
+# The index HTML file to drive the bundling process.
+target = "index.html"
+# Build in release mode.
+release = false
+# The output dir for all final assets.
+dist = "dist"
+# The public URL from which assets are to be served.
+public_url = "/"
+# Whether to include hash values in the output file names.
+filehash = true
+
+[watch]
+# Paths to watch. The `build.target`'s parent folder is watched by default.
+watch = []
+# Paths to ignore.
+ignore = []
+
+[serve]
+# The address to serve on.
+address = "127.0.0.1"
+# The port to serve on.
+port = 8080
+# Open a browser tab once the initial build is complete.
+open = false
+# Disable auto-reload of the web app.
+no_autoreload = false
+
+[clean]
+# The output dir for all final assets.
+dist = "dist"
+# Optionally perform a cargo clean.
+cargo = false
+
+[tools]
+# Default dart-sass version to download.
+sass = "1.54.9"
+# Default wasm-bindgen version to download.
+wasm_bindgen = "0.2.87"
+# Default wasm-opt version to download.
+wasm_opt = "version_110"
+# Default tailwindcss-cli version to download.
+tailwindcss = "3.3.2"

--- a/examples/popup/src/main.rs
+++ b/examples/popup/src/main.rs
@@ -1,6 +1,6 @@
 use futures::channel::oneshot;
 use log::*;
-use mapboxgl::{event, LngLat, Map, MapEventListener, MapFactory, MapOptions, Popup, PopupOptions};
+use mapboxgl::{event, LngLat, Map, MapEventListener, MapOptions, Popup, PopupOptions};
 use std::{cell::RefCell, rc::Rc};
 use yew::prelude::*;
 use yew::{use_effect_with_deps, use_mut_ref};
@@ -25,17 +25,17 @@ impl MapEventListener for Listener {
 }
 
 #[hook]
-fn use_map() -> Rc<RefCell<Option<MapFactory>>> {
-    let map = use_mut_ref(|| Option::<MapFactory>::None);
+fn use_map() -> Rc<RefCell<Option<Rc<Map>>>> {
+    let map = use_mut_ref(|| Option::<Rc<Map>>::None);
 
     {
         let map = map.clone();
         use_effect_with_deps(
             move |_| {
-                let mut m = create_map();
+                let m = create_map();
 
                 let (tx, rx) = oneshot::channel();
-                m.set_listener(Listener { tx: Some(tx) });
+                let _ = m.on(Listener { tx: Some(tx) });
 
                 wasm_bindgen_futures::spawn_local(async move {
                     rx.await.unwrap();
@@ -64,14 +64,14 @@ fn app() -> Html {
     }
 }
 
-pub fn create_map() -> MapFactory {
+pub fn create_map() -> Rc<Map> {
     let token = std::env!("MAPBOX_TOKEN");
 
     let opts = MapOptions::new(token.into(), "map".into())
         .center(LngLat::new(139.7647863, 35.6812373))
         .zoom(15.0);
 
-    mapboxgl::MapFactory::new(opts).unwrap()
+    Map::new(opts).unwrap()
 }
 
 fn main() {

--- a/examples/set-data/Trunk.toml
+++ b/examples/set-data/Trunk.toml
@@ -1,0 +1,45 @@
+# An example Trunk.toml with all possible fields along with their defaults.
+
+[build]
+# The index HTML file to drive the bundling process.
+target = "index.html"
+# Build in release mode.
+release = false
+# The output dir for all final assets.
+dist = "dist"
+# The public URL from which assets are to be served.
+public_url = "/"
+# Whether to include hash values in the output file names.
+filehash = true
+
+[watch]
+# Paths to watch. The `build.target`'s parent folder is watched by default.
+watch = []
+# Paths to ignore.
+ignore = []
+
+[serve]
+# The address to serve on.
+address = "127.0.0.1"
+# The port to serve on.
+port = 8080
+# Open a browser tab once the initial build is complete.
+open = false
+# Disable auto-reload of the web app.
+no_autoreload = false
+
+[clean]
+# The output dir for all final assets.
+dist = "dist"
+# Optionally perform a cargo clean.
+cargo = false
+
+[tools]
+# Default dart-sass version to download.
+sass = "1.54.9"
+# Default wasm-bindgen version to download.
+wasm_bindgen = "0.2.87"
+# Default wasm-opt version to download.
+wasm_opt = "version_110"
+# Default tailwindcss-cli version to download.
+tailwindcss = "3.3.2"

--- a/examples/simple/Trunk.toml
+++ b/examples/simple/Trunk.toml
@@ -1,0 +1,45 @@
+# An example Trunk.toml with all possible fields along with their defaults.
+
+[build]
+# The index HTML file to drive the bundling process.
+target = "index.html"
+# Build in release mode.
+release = false
+# The output dir for all final assets.
+dist = "dist"
+# The public URL from which assets are to be served.
+public_url = "/"
+# Whether to include hash values in the output file names.
+filehash = true
+
+[watch]
+# Paths to watch. The `build.target`'s parent folder is watched by default.
+watch = []
+# Paths to ignore.
+ignore = []
+
+[serve]
+# The address to serve on.
+address = "127.0.0.1"
+# The port to serve on.
+port = 8080
+# Open a browser tab once the initial build is complete.
+open = false
+# Disable auto-reload of the web app.
+no_autoreload = false
+
+[clean]
+# The output dir for all final assets.
+dist = "dist"
+# Optionally perform a cargo clean.
+cargo = false
+
+[tools]
+# Default dart-sass version to download.
+sass = "1.54.9"
+# Default wasm-bindgen version to download.
+wasm_bindgen = "0.2.87"
+# Default wasm-opt version to download.
+wasm_opt = "version_110"
+# Default tailwindcss-cli version to download.
+tailwindcss = "3.3.2"

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -1,11 +1,11 @@
-use mapboxgl::{LngLat, MapFactory, MapOptions};
+use mapboxgl::{LngLat, Map, MapOptions};
 use std::{cell::RefCell, rc::Rc};
 use yew::prelude::*;
 use yew::{use_effect_with_deps, use_mut_ref};
 
 #[hook]
-fn use_map() -> Rc<RefCell<Option<MapFactory>>> {
-    let map = use_mut_ref(|| Option::<MapFactory>::None);
+fn use_map() -> Rc<RefCell<Option<Rc<Map>>>> {
+    let map = use_mut_ref(|| Option::<Rc<Map>>::None);
 
     {
         let map = map.clone();
@@ -34,14 +34,14 @@ fn app() -> Html {
     }
 }
 
-pub fn create_map() -> MapFactory {
+pub fn create_map() -> Rc<Map> {
     let token = std::env!("MAPBOX_TOKEN");
 
     let opts = MapOptions::new(token.into(), "map".into())
         .center(LngLat::new(139.7647863, 35.6812373))
         .zoom(15.0);
 
-    mapboxgl::MapFactory::new(opts).unwrap()
+    Map::new(opts).unwrap()
 }
 
 fn main() {

--- a/examples/sycamore-simple/Trunk.toml
+++ b/examples/sycamore-simple/Trunk.toml
@@ -1,0 +1,45 @@
+# An example Trunk.toml with all possible fields along with their defaults.
+
+[build]
+# The index HTML file to drive the bundling process.
+target = "index.html"
+# Build in release mode.
+release = false
+# The output dir for all final assets.
+dist = "dist"
+# The public URL from which assets are to be served.
+public_url = "/"
+# Whether to include hash values in the output file names.
+filehash = true
+
+[watch]
+# Paths to watch. The `build.target`'s parent folder is watched by default.
+watch = []
+# Paths to ignore.
+ignore = []
+
+[serve]
+# The address to serve on.
+address = "127.0.0.1"
+# The port to serve on.
+port = 8080
+# Open a browser tab once the initial build is complete.
+open = false
+# Disable auto-reload of the web app.
+no_autoreload = false
+
+[clean]
+# The output dir for all final assets.
+dist = "dist"
+# Optionally perform a cargo clean.
+cargo = false
+
+[tools]
+# Default dart-sass version to download.
+sass = "1.54.9"
+# Default wasm-bindgen version to download.
+wasm_bindgen = "0.2.87"
+# Default wasm-opt version to download.
+wasm_opt = "version_110"
+# Default tailwindcss-cli version to download.
+tailwindcss = "3.3.2"

--- a/examples/sycamore-simple/src/main.rs
+++ b/examples/sycamore-simple/src/main.rs
@@ -1,4 +1,4 @@
-use mapboxgl::{LngLat, MapFactory, MapOptions};
+use mapboxgl::{LngLat, Map, MapOptions};
 use sycamore::prelude::*;
 use wasm_bindgen::{prelude::Closure, JsCast};
 use web_sys::window;
@@ -6,7 +6,7 @@ use web_sys::window;
 fn main() {
     window().unwrap().set_onload(Some(
         Closure::<dyn Fn()>::new(move || {
-            let _map = MapFactory::new(
+            let _map = Map::new(
                 MapOptions::new(std::env!("MAPBOX_TOKEN").into(), "map".into())
                     .center(LngLat::new(-88.6867772119069, 41.989067254515696))
                     .zoom(12.0),

--- a/src/js.rs
+++ b/src/js.rs
@@ -99,6 +99,14 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn on(this: &Map, r#type: String, callback: &Closure<dyn Fn(JsValue)>);
 
+    #[wasm_bindgen(method, js_name=on)]
+    pub fn on_layer(
+        this: &Map,
+        r#type: String,
+        layer_id: String,
+        callback: &Closure<dyn Fn(JsValue)>,
+    );
+
     #[wasm_bindgen(method)]
     pub fn getContainer(this: &Map) -> web_sys::HtmlElement;
 


### PR DESCRIPTION
I find MapFactory quite confusing because the name is "Factory" but it actually is a data structure that holds Map, Handle etc. Removed MapFactory and move all the functionalities to Map.

Other changes
* Rename set_listener to on
* Add on_layer, to register an event handler specific to the layer

Closes #47 