### PR TITLE
remove_marker doesn't need &mut

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -773,7 +773,7 @@ impl Map {
         id
     }
 
-    pub fn remove_marker(&mut self, id: &MarkerId) {
+    pub fn remove_marker(&self, id: &MarkerId) {
         self.markers
             .try_borrow_mut()
             .expect("Could not get lock for markders")


### PR DESCRIPTION
Hello! Thanks for putting this project together, I am using this with leptos, and having the remove_marker function take a mut self was tough to get around but it doesn't need to be mutable. Making this change made it easy to create a dynamically moving marker in leptos