### PR TITLE
Implement strongly typed layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ trunk serve
 	* [ ] [Working with events](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-working-with-events)
 	* [ ] [Sources](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-sources)
 	* [x] [Images](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-images)
-	* [ ] [Layers](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-layers)
+	* [x] [Layers](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-layers)
 	* [ ] [Style properties](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-style-properties)
 	* [ ] [Feature state](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-feature-state)
 	* [ ] [Lifecycle](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-lifecycle)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ trunk serve
 	* [ ] [Working with events](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-working-with-events)
 	* [ ] [Sources](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-sources)
 	* [x] [Images](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-images)
-	* [/] [Layers](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-layers)
+	* [x] [Layers](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-layers)
 	* [ ] [Style properties](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-style-properties)
 	* [ ] [Feature state](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-feature-state)
 	* [ ] [Lifecycle](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-lifecycle)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ trunk serve
 	* [ ] [Working with events](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-working-with-events)
 	* [ ] [Sources](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-sources)
 	* [x] [Images](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-images)
-	* [x] [Layers](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-layers)
+	* [/] [Layers](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-layers)
 	* [ ] [Style properties](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-style-properties)
 	* [ ] [Feature state](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-feature-state)
 	* [ ] [Lifecycle](https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-lifecycle)

--- a/examples/add-image/src/main.rs
+++ b/examples/add-image/src/main.rs
@@ -1,11 +1,12 @@
 use futures::channel::oneshot;
 use geojson::{Feature, FeatureCollection, GeoJson, Geometry, Value};
 use log::*;
+use mapboxgl::layer::SymbolLayer;
 use std::{cell::RefCell, rc::Rc};
 use yew::prelude::*;
 use yew::{use_effect_with_deps, use_mut_ref};
 
-use mapboxgl::{event, layer, ImageOptions, Layer, LngLat, Map, MapEventListener, MapOptions};
+use mapboxgl::{event, ImageOptions, LngLat, Map, MapEventListener, MapOptions};
 
 struct Listener {
     tx: Option<oneshot::Sender<()>>,
@@ -43,19 +44,10 @@ impl MapEventListener for Listener {
                     )
                     .unwrap();
 
-                    map2.add_layer(&Layer {
-                        id: "points".into(),
-                        r#type: "symbol".into(),
-                        source: "point".into(),
-                        layout: Some(layer::Layout {
-                            line_join: None,
-                            line_cap: None,
-                            icon_image: Some("cat".into()),
-                            icon_size: Some(0.25.into()),
-                        }),
-                        ..Default::default()
-                    })
-                    .unwrap();
+                    let mut sl = SymbolLayer::new("points", "point");
+                    sl.layout.icon_image = Some("cat".into());
+                    sl.layout.icon_size = Some(0.25.into());
+                    map2.add_layer(sl, None).unwrap();
                 }
             },
         );

--- a/examples/add-layer-below-labels/.gitignore
+++ b/examples/add-layer-below-labels/.gitignore
@@ -1,0 +1,2 @@
+/target
+/dist

--- a/examples/add-layer-below-labels/Cargo.toml
+++ b/examples/add-layer-below-labels/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "add-layer-below-labels"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+mapboxgl = { path = "../../" }
+leptos = { version = "0.6.11", features = ["csr"] }

--- a/examples/add-layer-below-labels/README.md
+++ b/examples/add-layer-below-labels/README.md
@@ -1,0 +1,12 @@
+## Add layer below labels
+
+Example derived from:
+https://docs.mapbox.com/mapbox-gl-js/example/geojson-layer-in-stack/
+
+In order to run this example you need to specify an [Mapbox access token](https://account.mapbox.com/access-tokens)
+
+```
+MAPBOX_TOKEN={ACCESS_TOKEN} trunk serve
+```
+
+Open http://127.0.0.1:8080 in your browser

--- a/examples/add-layer-below-labels/Trunk.toml
+++ b/examples/add-layer-below-labels/Trunk.toml
@@ -1,0 +1,2 @@
+[watch]
+watch = ["src", "index.html", "../../src"]

--- a/examples/add-layer-below-labels/index.html
+++ b/examples/add-layer-below-labels/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <script src='https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.js'></script>
+  <link href='https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.css' rel='stylesheet' />
+</head>
+
+<body style="margin: 0; padding: 0"></body>
+
+</html>

--- a/examples/add-layer-below-labels/index.html
+++ b/examples/add-layer-below-labels/index.html
@@ -2,8 +2,8 @@
 <html>
 
 <head>
-  <script src='https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.js'></script>
-  <link href='https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.css' rel='stylesheet' />
+  <script src='https://api.mapbox.com/mapbox-gl-js/v3.4.0/mapbox-gl.js'></script>
+  <link href='https://api.mapbox.com/mapbox-gl-js/v3.4.0/mapbox-gl.css' rel='stylesheet' />
 </head>
 
 <body style="margin: 0; padding: 0"></body>

--- a/examples/add-layer-below-labels/src/main.rs
+++ b/examples/add-layer-below-labels/src/main.rs
@@ -1,9 +1,7 @@
-use leptos::*;
+use leptos::{logging::log, *};
 use mapboxgl::FillLayer;
 use mapboxgl::{LngLat, Map, MapOptions};
-use std::any::Any;
 use std::rc::Rc;
-use web_sys::wasm_bindgen::JsValue;
 
 pub fn main() {
     leptos::mount_to_body(|| view! { <MapComponent/> });
@@ -13,6 +11,7 @@ struct MapListener {}
 
 impl mapboxgl::MapEventListener for MapListener {
     fn on_load(&mut self, map: Rc<mapboxgl::Map>, _e: mapboxgl::event::MapBaseEvent) {
+        log!("Running on load!");
         map.add_geojson_source_from_url(
             "urban-areas",
             "https://docs.mapbox.com/mapbox-gl-js/assets/ne_50m_urban_areas.geojson",
@@ -21,12 +20,10 @@ impl mapboxgl::MapEventListener for MapListener {
 
         let mut first_symbol_layer: Option<mapboxgl::layer::SymbolLayer> = None;
 
-        if let Some(layers) = map.get_style().layers {
-            for layer in layers {
-                if let mapboxgl::layer::Layer::Symbol(l) = layer {
-                    first_symbol_layer = Some(l);
-                    break;
-                }
+        for layer in map.get_style().layers {
+            if let mapboxgl::layer::Layer::Symbol(l) = layer {
+                first_symbol_layer = Some(l);
+                break;
             }
         }
 
@@ -34,7 +31,7 @@ impl mapboxgl::MapEventListener for MapListener {
         urban_areas_fill.paint.fill_color = Some("#f08".into());
         urban_areas_fill.paint.fill_opacity = Some(0.4.into());
 
-        map.add_layer(urban_areas_fill, first_symbol_layer.map(|l| l.inner.id))
+        map.add_layer(urban_areas_fill, first_symbol_layer.map(|l| l.id))
             .unwrap();
     }
 }
@@ -49,7 +46,7 @@ fn MapComponent() -> impl IntoView {
             let opts = MapOptions::new(token.into(), map.get_attribute("id").unwrap())
                 .center(LngLat::new(-88.137343, 35.137451))
                 .zoom(5.0)
-                .style("mapbox://styles/mapbox/standard".into());
+                .style_ref("mapbox://styles/mapbox/standard".into());
             let map = Map::new(opts).unwrap();
             map.on(MapListener {}).unwrap();
             map_store.set(Some(map));

--- a/examples/add-layer-below-labels/src/main.rs
+++ b/examples/add-layer-below-labels/src/main.rs
@@ -1,7 +1,9 @@
 use leptos::*;
 use mapboxgl::FillLayer;
 use mapboxgl::{LngLat, Map, MapOptions};
+use std::any::Any;
 use std::rc::Rc;
+use web_sys::wasm_bindgen::JsValue;
 
 pub fn main() {
     leptos::mount_to_body(|| view! { <MapComponent/> });
@@ -46,12 +48,27 @@ fn MapComponent() -> impl IntoView {
             let token = std::env!("MAPBOX_TOKEN");
             let opts = MapOptions::new(token.into(), map.get_attribute("id").unwrap())
                 .center(LngLat::new(-88.137343, 35.137451))
-                .zoom(3.0)
-                .style("mapbox://styles/mapbox/streets-v12".into());
+                .zoom(5.0)
+                .style("mapbox://styles/mapbox/standard".into());
             let map = Map::new(opts).unwrap();
             map.on(MapListener {}).unwrap();
             map_store.set(Some(map));
         });
     });
-    view! {<div id="map" style="position: absolute; top: 0; bottom: 0; width: 100%;" node_ref=map_ref/>}
+
+    // 'top' slot is meant for use with symbols, see: https://docs.mapbox.com/mapbox-gl-js/example/geojson-layer-in-slot/
+    let values = ["bottom", "middle"];
+    view! {
+        <>
+            <div id="map" style="position: absolute; top: 0; bottom: 0; width: 100%;" node_ref=map_ref/>
+            <div id="menu" style="position: absolute; background: #efefef; padding: 10px; font-family: 'Open Sans', sans-serif;">
+                {values.into_iter()
+                    .map(|n| view! {
+                        <label for=n>"move layer to: "{n}</label>
+                        <input id=n type="radio" name="rtoggle" value=n on:change={move |_e| map_store.get_untracked().unwrap().set_slot("urban-areas-fill", n).unwrap()} />
+                    })
+                    .collect::<Vec<_>>()}
+            </div>
+        </>
+    }
 }

--- a/examples/add-layer-below-labels/src/main.rs
+++ b/examples/add-layer-below-labels/src/main.rs
@@ -1,0 +1,57 @@
+use leptos::*;
+use mapboxgl::FillLayer;
+use mapboxgl::{LngLat, Map, MapOptions};
+use std::rc::Rc;
+
+pub fn main() {
+    leptos::mount_to_body(|| view! { <MapComponent/> });
+}
+
+struct MapListener {}
+
+impl mapboxgl::MapEventListener for MapListener {
+    fn on_load(&mut self, map: Rc<mapboxgl::Map>, _e: mapboxgl::event::MapBaseEvent) {
+        map.add_geojson_source_from_url(
+            "urban-areas",
+            "https://docs.mapbox.com/mapbox-gl-js/assets/ne_50m_urban_areas.geojson",
+        )
+        .unwrap();
+
+        let mut first_symbol_layer: Option<mapboxgl::layer::SymbolLayer> = None;
+
+        if let Some(layers) = map.get_style().layers {
+            for layer in layers {
+                if let mapboxgl::layer::Layer::Symbol(l) = layer {
+                    first_symbol_layer = Some(l);
+                    break;
+                }
+            }
+        }
+
+        let mut urban_areas_fill = FillLayer::new("urban-areas-fill", "urban-areas");
+        urban_areas_fill.paint.fill_color = Some("#f08".into());
+        urban_areas_fill.paint.fill_opacity = Some(0.4.into());
+
+        map.add_layer(urban_areas_fill, first_symbol_layer.map(|l| l.inner.id))
+            .unwrap();
+    }
+}
+
+#[component]
+fn MapComponent() -> impl IntoView {
+    let map_store = create_rw_signal(None);
+    let map_ref = create_node_ref::<html::Div>();
+    map_ref.on_load(move |m| {
+        let _map_el = m.on_mount(move |map| {
+            let token = std::env!("MAPBOX_TOKEN");
+            let opts = MapOptions::new(token.into(), map.get_attribute("id").unwrap())
+                .center(LngLat::new(-88.137343, 35.137451))
+                .zoom(3.0)
+                .style("mapbox://styles/mapbox/streets-v12".into());
+            let map = Map::new(opts).unwrap();
+            map.on(MapListener {}).unwrap();
+            map_store.set(Some(map));
+        });
+    });
+    view! {<div id="map" style="position: absolute; top: 0; bottom: 0; width: 100%;" node_ref=map_ref/>}
+}

--- a/examples/change-map-style/src/main.rs
+++ b/examples/change-map-style/src/main.rs
@@ -1,6 +1,6 @@
 use futures::channel::oneshot;
 use log::*;
-use mapboxgl::{event, LngLat, Map, MapEventListener, MapOptions, StyleOptions, StyleOrRef};
+use mapboxgl::{event, LngLat, Map, MapEventListener, MapOptions, StyleOptions};
 use std::{cell::RefCell, rc::Rc};
 use web_sys::HtmlInputElement;
 use yew::prelude::*;

--- a/examples/custom-layer/.gitignore
+++ b/examples/custom-layer/.gitignore
@@ -1,0 +1,4 @@
+/target
+/dist
+/app
+/node_modules

--- a/examples/custom-layer/Cargo.toml
+++ b/examples/custom-layer/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "custom-layer"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+mapboxgl = { path = "../../" }
+leptos = { version = "0.6.11", features = ["csr"] }
+console_error_panic_hook = "0.1.7"
+
+[dependencies.web-sys]
+version = "0.3.69"
+features = [
+  'console',
+  'Document',
+  'Element',
+  'HtmlCanvasElement',
+  'WebGlBuffer',
+  'WebGlFramebuffer',
+  'WebGlTexture',
+  'WebGlVertexArrayObject',
+  'WebGl2RenderingContext',
+  'WebGlUniformLocation',
+  'WebGlProgram',
+  'WebGlShader',
+  'Window',
+  'Performance',
+]

--- a/examples/custom-layer/README.md
+++ b/examples/custom-layer/README.md
@@ -1,0 +1,9 @@
+## Leptos with Mapbox simple Example
+
+In order to run this example you need to specify an [Mapbox access token](https://account.mapbox.com/access-tokens)
+
+```
+MAPBOX_TOKEN={ACCESS_TOKEN} trunk serve
+```
+
+Open http://127.0.0.1:8080 in your browser

--- a/examples/custom-layer/Trunk.toml
+++ b/examples/custom-layer/Trunk.toml
@@ -1,0 +1,2 @@
+[watch]
+watch = ["src", "index.html", "../../src"]

--- a/examples/custom-layer/index.html
+++ b/examples/custom-layer/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <script src='https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.js'></script>
+  <link href='https://api.mapbox.com/mapbox-gl-js/v3.3.0/mapbox-gl.css' rel='stylesheet' />
+</head>
+
+<body style="margin: 0; padding: 0"></body>
+
+</html>

--- a/examples/custom-layer/src/main.rs
+++ b/examples/custom-layer/src/main.rs
@@ -25,7 +25,7 @@ impl mapboxgl::MapEventListener for Listener {
 
 #[component]
 fn MapComponent() -> impl IntoView {
-    let triangle = vec![[25.004, 60.239], [13.403, 52.562], [30.498, 50.541]];
+    let triangle = [[25.004, 60.239], [13.403, 52.562], [30.498, 50.541]];
     let vertex_data: Vec<f32> = triangle
         .iter()
         .flat_map(|p| {
@@ -106,8 +106,8 @@ fn MapComponent() -> impl IntoView {
 }
 
 fn create_program(gl: &GL, vert_shader: &str, frag_shader: &str) -> Result<WebGlProgram, String> {
-    let vert_shader = compile_shader(gl, GL::VERTEX_SHADER, &vert_shader)?;
-    let frag_shader = compile_shader(gl, GL::FRAGMENT_SHADER, &frag_shader)?;
+    let vert_shader = compile_shader(gl, GL::VERTEX_SHADER, vert_shader)?;
+    let frag_shader = compile_shader(gl, GL::FRAGMENT_SHADER, frag_shader)?;
     let program = gl
         .create_program()
         .ok_or_else(|| String::from("Unable to create shader object"))?;

--- a/examples/custom-layer/src/main.rs
+++ b/examples/custom-layer/src/main.rs
@@ -1,0 +1,153 @@
+use leptos::{logging::log, *};
+use mapboxgl::{CustomLayer, LngLat, Map, MapOptions};
+use std::rc::Rc;
+
+use std::f64::consts::PI as PIf64;
+use wasm_bindgen::prelude::*;
+use web_sys::{WebGl2RenderingContext as GL, WebGlBuffer, WebGlProgram, WebGlShader};
+
+pub fn main() {
+    console_error_panic_hook::set_once();
+    leptos::mount_to_body(|| view! { <MapComponent/> });
+}
+
+#[derive(Clone, Debug, Default)]
+struct Listener {
+    cl: CustomLayer,
+}
+
+impl mapboxgl::MapEventListener for Listener {
+    fn on_load(&mut self, map: Rc<mapboxgl::Map>, e: mapboxgl::event::MapBaseEvent) {
+        log!("loaaaaddededededde {:?} ", e);
+        map.add_layer(self.cl.clone(), None).unwrap();
+    }
+}
+
+#[component]
+fn MapComponent() -> impl IntoView {
+    let triangle = vec![[25.004, 60.239], [13.403, 52.562], [30.498, 50.541]];
+    let vertex_data: Vec<f32> = triangle
+        .iter()
+        .flat_map(|p| {
+            let merc_pos = lonlat_to_mercator(p[0], p[1]);
+            [merc_pos.0 as f32, merc_pos.1 as f32]
+        })
+        .collect();
+    let gl_data: RwSignal<Option<(WebGlProgram, WebGlBuffer)>> = create_rw_signal(None);
+
+    let map_store = create_rw_signal(None);
+    let map_ref = create_node_ref::<html::Div>();
+    map_ref.on_load(move |m| {
+        let _map_el = m.on_mount(move |map| {
+            let token = std::env!("MAPBOX_TOKEN");
+            let map = Map::new(
+                MapOptions::new(token.into(), map.get_attribute("id").unwrap())
+                    .center(LngLat::new(19.7, 59.9))
+                    .zoom(4.0),
+            )
+            .unwrap();
+
+            let on_add = move |_map, raw_gl: JsValue| {
+                let gl: GL = raw_gl.dyn_into().unwrap();
+
+                let vertex_source = "
+                uniform mat4 u_matrix;
+                attribute vec2 a_pos;
+                void main() {
+                    gl_Position = u_matrix * vec4(a_pos, 0.0, 1.0);
+                }";
+
+                let fragment_source = "
+                void main() {
+                    gl_FragColor = vec4(1.0, 0.0, 0.0, 0.5);
+                }";
+
+                let main_program = create_program(&gl, vertex_source, fragment_source).unwrap();
+                gl.use_program(Some(&main_program));
+                let vertex_buffer = gl.create_buffer().unwrap();
+
+                gl.bind_buffer(GL::ARRAY_BUFFER, Some(&vertex_buffer));
+                gl_data.set(Some((main_program, vertex_buffer)));
+
+                gl.buffer_data_with_array_buffer_view(
+                    GL::ARRAY_BUFFER,
+                    &web_sys::js_sys::Float32Array::from(vertex_data.as_slice()),
+                    GL::STATIC_DRAW,
+                );
+            };
+            let render = move |raw_gl: JsValue, matrix: JsValue| {
+                let gl: GL = raw_gl.dyn_into().unwrap();
+                if let Some((main_program, main_buffer)) = gl_data.get_untracked() {
+                    gl.use_program(Some(&main_program));
+                    gl.bind_buffer(GL::ARRAY_BUFFER, Some(&main_buffer));
+                    let pos_atrib_loc = gl.get_attrib_location(&main_program, "a_pos") as u32;
+                    gl.enable_vertex_attrib_array(pos_atrib_loc);
+                    gl.vertex_attrib_pointer_with_i32(pos_atrib_loc, 2, GL::FLOAT, false, 0, 0);
+
+                    let mut mat: [f64; 16] = [0.0; 16];
+                    web_sys::js_sys::Float64Array::from(matrix).copy_to(&mut mat);
+                    let f32_mat: Vec<f32> = mat.iter().map(|v| *v as f32).collect();
+
+                    gl.uniform_matrix4fv_with_f32_array(
+                        gl.get_uniform_location(&main_program, "u_matrix").as_ref(),
+                        false,
+                        f32_mat.as_slice(),
+                    );
+                    gl.draw_arrays(GL::TRIANGLES, 0, 3);
+                }
+            };
+            let mut cl = CustomLayer::new("triangle", "", render);
+            cl.set_on_add(on_add);
+            map.on(Listener { cl }).unwrap();
+            map_store.set(Some(map));
+        });
+    });
+    view! {<div id="map" style="position: absolute; top: 0; bottom: 0; width: 100%;" node_ref=map_ref/>}
+}
+
+fn create_program(gl: &GL, vert_shader: &str, frag_shader: &str) -> Result<WebGlProgram, String> {
+    let vert_shader = compile_shader(gl, GL::VERTEX_SHADER, &vert_shader)?;
+    let frag_shader = compile_shader(gl, GL::FRAGMENT_SHADER, &frag_shader)?;
+    let program = gl
+        .create_program()
+        .ok_or_else(|| String::from("Unable to create shader object"))?;
+    gl.attach_shader(&program, &vert_shader);
+    gl.attach_shader(&program, &frag_shader);
+    gl.link_program(&program);
+    if !gl
+        .get_program_parameter(&program, GL::LINK_STATUS)
+        .as_bool()
+        .unwrap_or(false)
+    {
+        Err(gl
+            .get_program_info_log(&program)
+            .unwrap_or_else(|| String::from("Unknown error creating program object")))?;
+    }
+    Ok(program)
+}
+
+fn compile_shader(gl: &GL, shader_type: u32, source: &str) -> Result<WebGlShader, String> {
+    let shader = gl
+        .create_shader(shader_type)
+        .ok_or_else(|| String::from("Unable to create shader object"))?;
+    gl.shader_source(&shader, source);
+    gl.compile_shader(&shader);
+
+    match gl
+        .get_shader_parameter(&shader, GL::COMPILE_STATUS)
+        .as_bool()
+        .unwrap_or(false)
+    {
+        true => Ok(shader),
+        false => Err(gl
+            .get_shader_info_log(&shader)
+            .unwrap_or_else(|| String::from("Unknown error creating shader"))),
+    }
+}
+
+fn lonlat_to_mercator(longitude: f64, latitude: f64) -> (f64, f64) {
+    let lat_rad = latitude * PIf64 / 180.0;
+    let merc_n = (PIf64 / 4.0 + lat_rad / 2.0).tan().ln();
+    let y = 0.5 - merc_n / (2.0 * PIf64);
+    ((longitude + 180.0) / 360.0, y)
+}

--- a/examples/geojson-source/src/main.rs
+++ b/examples/geojson-source/src/main.rs
@@ -1,6 +1,7 @@
 use futures::channel::oneshot;
 use log::*;
-use mapboxgl::{event, layer, Layer, LngLat, Map, MapEventListener, MapOptions};
+use mapboxgl::layer::{LineCap, LineJoin, LineLayer};
+use mapboxgl::{event, LngLat, Map, MapEventListener, MapOptions};
 use std::{cell::RefCell, rc::Rc};
 use yew::prelude::*;
 use yew::{use_effect_with_deps, use_mut_ref};
@@ -49,23 +50,13 @@ impl MapEventListener for Listener {
         )
         .unwrap();
 
-        map.add_layer(&Layer {
-            id: "route".into(),
-            r#type: "line".into(),
-            source: "route".into(),
-            layout: Some(layer::Layout {
-                line_join: Some("round".into()),
-                line_cap: Some("round".into()),
-                icon_image: None,
-                icon_size: None,
-            }),
-            paint: Some(layer::Paint {
-                line_color: "#888".into(),
-                line_width: 8,
-            }),
-            ..Default::default()
-        })
-        .unwrap();
+        let mut line_layer = LineLayer::new("route", "route");
+        line_layer.layout.line_join = Some(LineJoin::Round.into());
+        line_layer.layout.line_cap = Some(LineCap::Round.into());
+        line_layer.paint.line_color = Some("#888".into());
+        line_layer.paint.line_width = Some(8.0.into());
+
+        map.add_layer(line_layer, None).unwrap();
     }
 }
 

--- a/examples/set-data/src/main.rs
+++ b/examples/set-data/src/main.rs
@@ -2,7 +2,8 @@ use anyhow::Context;
 use futures::channel::oneshot;
 use gloo::timers::future::TimeoutFuture;
 use log::*;
-use mapboxgl::{event, layer, Layer, LngLat, Map, MapEventListener, MapOptions};
+use mapboxgl::layer::{LineCap, LineJoin, LineLayer};
+use mapboxgl::{event, LngLat, Map, MapEventListener, MapOptions};
 use std::{cell::RefCell, ops::Deref, rc::Rc};
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::JsFuture;
@@ -180,23 +181,13 @@ fn update(map: MapRef, route: &RouteState, second: &IntervalState) -> anyhow::Re
 fn add_data(map: &Map, json: geojson::FeatureCollection) -> anyhow::Result<()> {
     map.add_geojson_source("trace", geojson::GeoJson::FeatureCollection(json))?;
 
-    map.add_layer(&Layer {
-        id: "trace".into(),
-        r#type: "line".into(),
-        source: "trace".into(),
-        layout: Some(layer::Layout {
-            line_join: Some("round".into()),
-            line_cap: Some("round".into()),
-            icon_image: None,
-            icon_size: None,
-        }),
-        paint: Some(layer::Paint {
-            line_color: "yellow".into(),
-            line_width: 8,
-        }),
-        ..Default::default()
-    })?;
+    let mut ll = LineLayer::new("trace", "trace");
+    ll.paint.line_color = Some("yellow".into());
+    ll.paint.line_width = Some(8.0.into());
+    ll.layout.line_join = Some(LineJoin::Round.into());
+    ll.layout.line_cap = Some(LineCap::Round.into());
 
+    map.add_layer(ll, None)?;
     Ok(())
 }
 

--- a/examples/simple-style-struct/src/main.rs
+++ b/examples/simple-style-struct/src/main.rs
@@ -1,4 +1,6 @@
-use mapboxgl::{Layer, LngLat, Map, MapOptions, Source, Sources, Style};
+use mapboxgl::layer::{IntoLayer, Layer, RasterLayer};
+use mapboxgl::style::Sources;
+use mapboxgl::{LngLat, Map, MapOptions, Source, Style};
 use std::{cell::RefCell, rc::Rc};
 use yew::prelude::*;
 use yew::{use_effect_with_deps, use_mut_ref};
@@ -42,22 +44,23 @@ pub fn create_map() -> Rc<Map> {
         "carto-dark".into(),
         Source {
             r#type: "raster".into(),
-            tiles: vec![
+            tiles: Some(vec![
                 "http://a.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png".into(),
                 "http://b.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png".into(),
                 "http://c.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png".into(),
                 "http://d.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png".into(),
-            ],
+            ]),
+            ..Default::default()
         },
     );
-    let layers: Vec<Layer> = vec![Layer {
+    let layers: Vec<Layer> = vec![RasterLayer {
         id: "carto-dark-layer".into(),
-        r#type: "raster".into(),
         source: "carto-dark".into(),
         minzoom: Some(0.0),
         maxzoom: Some(21.0),
         ..Default::default()
-    }];
+    }
+    .into_layer()];
     let opts = MapOptions::new(token.into(), "map".into())
         .center(LngLat::new(139.7647863, 35.6812373))
         .zoom(15.0)
@@ -65,6 +68,7 @@ pub fn create_map() -> Rc<Map> {
             version: 8,
             sources,
             layers,
+            ..Default::default()
         });
 
     Map::new(opts).unwrap()

--- a/src/js.rs
+++ b/src/js.rs
@@ -183,9 +183,11 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn triggerRepaint(this: &Map);
 
+    // Querying features
     #[wasm_bindgen(method)]
     pub fn queryRenderedFeatures(map: &Map, geometry: JsValue, options: JsValue) -> JsValue;
 
+    // Sources
     #[wasm_bindgen(method)]
     pub fn addSource(this: &Map, id: String, source: JsValue);
 
@@ -201,15 +203,59 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn getSource(this: &Map, id: String) -> JsValue;
 
+    // Layer
     #[wasm_bindgen(method)]
     pub fn addLayer(this: &Map, value: JsValue, before_id: Option<String>);
+
+    #[wasm_bindgen(method)]
+    pub fn getSlot(this: &Map, id: String) -> Option<String>;
+
+    #[wasm_bindgen(method)]
+    pub fn setSlot(this: &Map, id: String, slot: String) -> JsValue;
+
+    #[wasm_bindgen(method)]
+    pub fn moveLayer(this: &Map, id: String, before_id: Option<String>) -> JsValue;
+
+    #[wasm_bindgen(method)]
+    pub fn removeLayer(this: &Map, id: String) -> JsValue;
 
     #[wasm_bindgen(method)]
     pub fn getLayer(this: &Map, id: String) -> JsValue;
 
     #[wasm_bindgen(method)]
+    pub fn setLayerZoomRange(this: &Map, id: String, min_zoom: f64, max_zoom: f64) -> JsValue;
+
+    #[wasm_bindgen(method)]
+    pub fn setFilter(this: &Map, id: String, filter: JsValue, options: JsValue) -> JsValue;
+
+    #[wasm_bindgen(method)]
+    pub fn getFilter(this: &Map, id: String) -> JsValue;
+
+    #[wasm_bindgen(method)]
+    pub fn setPaintProperty(
+        this: &Map,
+        id: String,
+        name: String,
+        value: JsValue,
+        options: JsValue,
+    ) -> JsValue;
+
+    #[wasm_bindgen(method)]
     pub fn getPaintProperty(this: &Map, id: String, name: String) -> JsValue;
 
+    #[wasm_bindgen(method)]
+    pub fn setLayoutProperty(
+        this: &Map,
+        id: String,
+        name: String,
+        value: JsValue,
+        options: JsValue,
+    ) -> JsValue;
+
+    #[wasm_bindgen(method)]
+    pub fn getLayoutProperty(this: &Map, id: String, name: String) -> JsValue;
+
+    // Debug Features
     #[wasm_bindgen(method, setter)]
     pub fn set_showTileBoundaries(this: &Map, v: bool) -> Map;
 

--- a/src/js.rs
+++ b/src/js.rs
@@ -137,6 +137,9 @@ extern "C" {
     #[wasm_bindgen(method)]
     pub fn setStyle(this: &Map, style: JsValue, options: JsValue) -> bool;
 
+    #[wasm_bindgen(method)]
+    pub fn getStyle(this: &Map) -> JsValue;
+
     // Images
 
     /// Add image resource.
@@ -199,7 +202,13 @@ extern "C" {
     pub fn getSource(this: &Map, id: String) -> JsValue;
 
     #[wasm_bindgen(method)]
-    pub fn addLayer(this: &Map, value: JsValue);
+    pub fn addLayer(this: &Map, value: JsValue, before_id: Option<String>);
+
+    #[wasm_bindgen(method)]
+    pub fn getLayer(this: &Map, id: String) -> JsValue;
+
+    #[wasm_bindgen(method)]
+    pub fn getPaintProperty(this: &Map, id: String, name: String) -> JsValue;
 
     #[wasm_bindgen(method, setter)]
     pub fn set_showTileBoundaries(this: &Map, v: bool) -> Map;

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,102 +1,732 @@
-use serde::{Deserialize, Serialize};
+use std::fmt;
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Layer {
+use serde::{Deserialize, Serialize};
+use wasm_bindgen::{closure::Closure, JsValue};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Expression<T> {
+    Enum(T),
+    String(String),
+    Number(f64),
+    Bool(bool),
+    List(Vec<Expression<T>>),
+}
+
+pub trait EnumMarker {}
+impl<T: EnumMarker> From<T> for Expression<T> {
+    fn from(item: T) -> Self {
+        Expression::Enum(item)
+    }
+}
+impl<T> From<&str> for Expression<T> {
+    fn from(value: &str) -> Self {
+        Expression::String(value.into())
+    }
+}
+
+impl<T> From<String> for Expression<T> {
+    fn from(value: String) -> Self {
+        Expression::String(value)
+    }
+}
+
+impl<T> From<f64> for Expression<T> {
+    fn from(value: f64) -> Self {
+        Expression::Number(value)
+    }
+}
+
+impl<T> From<bool> for Expression<T> {
+    fn from(value: bool) -> Self {
+        Expression::Bool(value)
+    }
+}
+
+impl<T> From<Vec<&str>> for Expression<T> {
+    fn from(value: Vec<&str>) -> Self {
+        Expression::List(value.into_iter().map(|s| s.into()).collect())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum Visibility {
+    #[default]
+    Visible,
+    None,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct GetLayer {
     pub id: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub layout: Option<Layout>,
+    #[serde(rename = "type")]
+    pub type_: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub maxzoom: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub minzoom: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub paint: Option<Paint>,
+    pub visibility: Option<Visibility>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum Layer {
+    Custom(CustomLayer),
+    Fill(FillLayer),
+    Background(BackgroundLayer),
+    Line(LineLayer),
+    Symbol(SymbolLayer),
+    Circle(CircleLayer),
+}
+
+pub trait IntoLayer {
+    fn into_layer(self) -> Layer;
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LayerBase {
+    pub id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub rendering_mode: Option<String>,
+    pub maxzoom: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minzoom: Option<f64>,
     pub source: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<Expression<()>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "source-layer")]
     pub source_layer: Option<String>,
-    pub r#type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slot: Option<String>,
 }
 
-impl Layer {
-    pub fn new(
-        id: impl Into<String>,
-        r#type: impl Into<String>,
-        source: impl Into<String>,
-    ) -> Layer {
-        Layer {
+impl LayerBase {
+    pub fn new(id: impl Into<String>, source: impl Into<String>) -> LayerBase {
+        LayerBase {
             id: id.into(),
-            layout: None,
             maxzoom: None,
             minzoom: None,
-            paint: None,
-            rendering_mode: None,
             source: source.into(),
+            filter: None,
             source_layer: None,
-            r#type: r#type.into(),
+            slot: None,
         }
     }
 }
 
-/// Layout property can be either value in String or Number e.g. 0.25
-/// or tuple of 2 elements, ("get", "icon").
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum LayoutProperty {
-    String(String),
-    Number(f64),
-    FeatureProperty((String, String)),
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomLayer {
+    #[serde(flatten)]
+    pub inner: LayerBase,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rendering_mode: Option<String>,
+    #[serde(with = "serde_wasm_bindgen::preserve")]
+    pub on_add: js_sys::Function,
+    #[serde(with = "serde_wasm_bindgen::preserve")]
+    pub on_remove: js_sys::Function,
+    #[serde(with = "serde_wasm_bindgen::preserve")]
+    pub prerender: js_sys::Function,
+    #[serde(with = "serde_wasm_bindgen::preserve")]
+    pub render: js_sys::Function,
 }
 
-impl From<&str> for LayoutProperty {
-    fn from(value: &str) -> Self {
-        LayoutProperty::String(value.into())
+impl IntoLayer for CustomLayer {
+    fn into_layer(self) -> Layer {
+        Layer::Custom(self)
     }
 }
 
-impl From<String> for LayoutProperty {
-    fn from(value: String) -> Self {
-        LayoutProperty::String(value)
+fn make_wasm_closure(some_fn: impl Fn(JsValue, JsValue) + 'static) -> js_sys::Function {
+    Closure::<dyn Fn(JsValue, JsValue)>::new(some_fn)
+        .into_js_value()
+        .into()
+}
+
+impl CustomLayer {
+    pub fn new<F>(id: impl Into<String>, source: impl Into<String>, render: F) -> CustomLayer
+    where
+        F: 'static + Fn(JsValue, JsValue),
+    {
+        let render = Closure::<dyn Fn(JsValue, JsValue)>::new(render);
+        CustomLayer {
+            inner: LayerBase::new(id, source),
+            rendering_mode: None,
+            // Use no-ops for the optional functions
+            on_add: make_wasm_closure(|_1, _2| {}),
+            on_remove: make_wasm_closure(|_1, _2| {}),
+            prerender: make_wasm_closure(|_1, _2| {}),
+            render: render.into_js_value().into(),
+        }
+    }
+    pub fn set_on_add(&mut self, on_add_fn: impl Fn(JsValue, JsValue) + 'static) {
+        self.on_add = make_wasm_closure(on_add_fn);
+    }
+    pub fn set_on_remove(&mut self, on_remove_fn: impl Fn(JsValue, JsValue) + 'static) {
+        self.on_remove = make_wasm_closure(on_remove_fn);
+    }
+    pub fn set_render(&mut self, render_fn: impl Fn(JsValue, JsValue) + 'static) {
+        self.render = make_wasm_closure(render_fn);
+    }
+    pub fn set_prerender(&mut self, prerender_fn: impl Fn(JsValue, JsValue) + 'static) {
+        self.prerender = make_wasm_closure(prerender_fn);
     }
 }
 
-impl From<f64> for LayoutProperty {
-    fn from(value: f64) -> Self {
-        LayoutProperty::Number(value)
+impl<T: fmt::Debug> fmt::Display for Expression<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Expression::String(s) => write!(f, "\"{}\"", s),
+            Expression::Number(n) => write!(f, "{}", n),
+            Expression::Bool(b) => write!(f, "{}", b),
+            Expression::List(list) => {
+                write!(f, "[")?;
+                for (index, item) in list.iter().enumerate() {
+                    if index > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", item)?;
+                }
+                write!(f, "]")
+            }
+            Expression::Enum(e) => write!(f, "{:?}", e),
+        }
     }
 }
 
-impl From<(String, String)> for LayoutProperty {
-    fn from((verb, name): (String, String)) -> Self {
-        LayoutProperty::FeatureProperty((verb, name))
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FillLayer {
+    #[serde(flatten)]
+    pub inner: LayerBase,
+    #[serde(default)]
+    pub layout: FillLayout,
+    #[serde(default)]
+    pub paint: FillPaint,
+}
+
+impl IntoLayer for FillLayer {
+    fn into_layer(self) -> Layer {
+        Layer::Fill(self)
     }
 }
 
-impl From<(&str, &str)> for LayoutProperty {
-    fn from((verb, name): (&str, &str)) -> Self {
-        LayoutProperty::FeatureProperty((verb.into(), name.into()))
+impl FillLayer {
+    pub fn new(id: impl Into<String>, source: impl Into<String>) -> FillLayer {
+        FillLayer {
+            inner: LayerBase::new(id, source),
+            layout: FillLayout::default(),
+            paint: FillPaint::default(),
+        }
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
-pub struct Layout {
+pub enum TranslateAnchor {
+    #[default]
+    Map,
+    Viewport,
+}
+impl EnumMarker for TranslateAnchor {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct FillPaint {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line_join: Option<LayoutProperty>,
+    pub fill_antialias: Option<Expression<()>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub line_cap: Option<LayoutProperty>,
+    pub fill_color: Option<Expression<()>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub icon_image: Option<LayoutProperty>,
+    pub fill_emissive_strength: Option<Expression<()>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub icon_size: Option<LayoutProperty>,
+    pub fill_opacity: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fill_outline_color: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fill_pattern: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fill_translate: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fill_translate_anchor: Option<Expression<TranslateAnchor>>,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
-pub struct Paint {
-    pub line_color: String,
-    pub line_width: u32,
+pub struct FillLayout {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub fill_sort_key: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<Visibility>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BackgroundLayer {
+    pub id: String,
+    #[serde(default)]
+    pub layout: BackgroundLayout,
+    #[serde(default)]
+    pub paint: BackgroundPaint,
+}
+
+impl IntoLayer for BackgroundLayer {
+    fn into_layer(self) -> Layer {
+        Layer::Background(self)
+    }
+}
+
+impl BackgroundLayer {
+    pub fn new(id: impl Into<String>) -> BackgroundLayer {
+        BackgroundLayer {
+            id: id.into(),
+            layout: BackgroundLayout::default(),
+            paint: BackgroundPaint::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct BackgroundPaint {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background_color: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background_emissive_strength: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background_opacity: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background_pattern: Option<Expression<()>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct BackgroundLayout {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<Visibility>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LineLayer {
+    #[serde(flatten)]
+    pub inner: LayerBase,
+    #[serde(default)]
+    pub layout: LineLayout,
+    #[serde(default)]
+    pub paint: LinePaint,
+}
+
+impl IntoLayer for LineLayer {
+    fn into_layer(self) -> Layer {
+        Layer::Line(self)
+    }
+}
+
+impl LineLayer {
+    pub fn new(id: impl Into<String>, source: impl Into<String>) -> LineLayer {
+        LineLayer {
+            inner: LayerBase::new(id, source),
+            layout: LineLayout::default(),
+            paint: LinePaint::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum LineCap {
+    #[default]
+    Butt,
+    Round,
+    Square,
+}
+impl EnumMarker for LineCap {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum LineJoin {
+    #[default]
+    Miter,
+    Bevel,
+    Round,
+    None,
+}
+impl EnumMarker for LineJoin {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct LinePaint {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_blur: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_color: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_dasharray: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_emissive_strength: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_gap_width: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_gradient: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_offset: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_opacity: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_pattern: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_translate: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_translate_anchor: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_trim_offset: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_width: Option<Expression<()>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct LineLayout {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_cap: Option<Expression<LineCap>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_join: Option<Expression<LineJoin>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_miter_limit: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_round_limit: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line_sort_key: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<Visibility>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SymbolLayer {
+    #[serde(flatten)]
+    pub inner: LayerBase,
+    #[serde(default)]
+    pub layout: SymbolLayout,
+    #[serde(default)]
+    pub paint: SymbolPaint,
+}
+
+impl IntoLayer for SymbolLayer {
+    fn into_layer(self) -> Layer {
+        Layer::Symbol(self)
+    }
+}
+
+impl SymbolLayer {
+    pub fn new(id: impl Into<String>, source: impl Into<String>) -> SymbolLayer {
+        SymbolLayer {
+            inner: LayerBase::new(id, source),
+            layout: SymbolLayout::default(),
+            paint: SymbolPaint::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum Anchor {
+    #[default]
+    Center,
+    Left,
+    Right,
+    Top,
+    Bottom,
+    TopLeft,
+    TopRight,
+    BottomLeft,
+    BottomRight,
+}
+impl EnumMarker for Anchor {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum Alignment {
+    #[default]
+    Auto,
+    Map,
+    Viewport,
+}
+impl EnumMarker for Alignment {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum IconTextFit {
+    #[default]
+    None,
+    Width,
+    Height,
+    Both,
+}
+impl EnumMarker for IconTextFit {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum SymbolPlacement {
+    #[default]
+    Point,
+    Line,
+    LineCenter,
+}
+impl EnumMarker for SymbolPlacement {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum SymbolZOrder {
+    #[default]
+    Auto,
+    ViewportY,
+    Source,
+}
+impl EnumMarker for SymbolZOrder {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum TextJustify {
+    #[default]
+    Center,
+    Auto,
+    Left,
+    Right,
+}
+impl EnumMarker for TextJustify {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum TextTransform {
+    #[default]
+    None,
+    Uppercase,
+    Lowercase,
+}
+impl EnumMarker for TextTransform {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct SymbolPaint {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_color: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_color_brightness_max: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_color_brightness_min: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_color_contrast: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_color_saturation: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_emissive_strength: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_halo_blur: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_halo_color: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_halo_width: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_image_cross_fade: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_opacity: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_translate: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_translate_anchor: Option<Expression<TranslateAnchor>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_color: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_emissive_strength: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_halo_blur: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_halo_color: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_halo_width: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_opacity: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_translate: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_translate_anchor: Option<Expression<TranslateAnchor>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct SymbolLayout {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_allow_overlap: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_anchor: Option<Expression<Anchor>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_ignore_placement: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_image: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_keep_upright: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_offset: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_optional: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_padding: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_pitch_alignment: Option<Expression<Alignment>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_rotate: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_rotation_alignment: Option<Expression<Alignment>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_size: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_text_fit: Option<Expression<IconTextFit>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_text_fit_padding: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbol_avoid_edges: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbol_placement: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbol_sort_key: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbol_spacing: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbol_z_elevate: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub symbol_z_order: Option<Expression<SymbolZOrder>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_allow_overlap: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_anchor: Option<Expression<Anchor>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_field: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_font: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_ignore_placement: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_justify: Option<Expression<TextJustify>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_keep_upright: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_letter_spacing: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_line_height: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_max_angle: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_max_width: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_offset: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_optional: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_padding: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_pitch_alignment: Option<Expression<Alignment>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_radial_offset: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_rotate: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_rotation_alignment: Option<Expression<Alignment>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_size: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_transform: Option<Expression<TextTransform>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_variable_anchor: Option<Expression<Anchor>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text_writing_mode: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<Visibility>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CircleLayer {
+    #[serde(flatten)]
+    pub inner: LayerBase,
+    #[serde(default)]
+    pub layout: CircleLayout,
+    #[serde(default)]
+    pub paint: CirclePaint,
+}
+
+impl IntoLayer for CircleLayer {
+    fn into_layer(self) -> Layer {
+        Layer::Circle(self)
+    }
+}
+
+impl CircleLayer {
+    pub fn new(id: impl Into<String>, source: impl Into<String>) -> CircleLayer {
+        CircleLayer {
+            inner: LayerBase::new(id, source),
+            layout: CircleLayout::default(),
+            paint: CirclePaint::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum CircleAlignment {
+    #[default]
+    Viewport,
+    Map,
+}
+impl EnumMarker for CircleAlignment {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub enum CircleScale {
+    #[default]
+    Map,
+    Viewport,
+}
+impl EnumMarker for CircleScale {}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct CirclePaint {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub circle_blur: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub circle_color: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub circle_emissive_strength: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub circle_opacity: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub circle_pitch_alignment: Option<Expression<CircleAlignment>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub circle_pitch_scale: Option<Expression<CircleScale>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub circle_radius: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub circle_stroke_color: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub circle_stroke_opacity: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub circle_stroke_width: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub circle_translate: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub circle_translate_anchor: Option<Expression<TranslateAnchor>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+#[serde(rename_all = "kebab-case")]
+pub struct CircleLayout {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub circle_sort_key: Option<Expression<()>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<Visibility>,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,7 @@ use std::{
     rc::{Rc, Weak},
 };
 use wasm_bindgen::{prelude::*, JsCast};
+// use web_sys::window;
 
 use callback::CallbackStore;
 pub use error::{Error, Result};
@@ -544,6 +545,13 @@ impl Map {
 
         let inner = crate::js::Map::new(options);
 
+        // js_sys::Reflect::set(
+        //     &JsValue::from(web_sys::window().unwrap()),
+        //     &JsValue::from("mappy"),
+        //     &inner,
+        // )
+        // .unwrap();
+
         let map = Rc::new(Map {
             inner,
             handles: RefCell::new(HashMap::new()),
@@ -883,15 +891,51 @@ impl Map {
         Ok(())
     }
 
+    pub fn get_slot(&self, id: impl Into<String>) -> Option<String> {
+        self.inner.getSlot(id.into())
+    }
+
+    pub fn set_slot(&self, id: impl Into<String>, slot: impl Into<String>) -> Result<()> {
+        self.inner.setSlot(id.into(), slot.into());
+        Ok(())
+    }
+
+    pub fn move_layer(&self, id: impl Into<String>, before_id: Option<String>) -> Result<()> {
+        self.inner.moveLayer(id.into(), before_id);
+        Ok(())
+    }
+
+    pub fn remove_layer(&self, id: impl Into<String>) -> Result<()> {
+        self.inner.removeLayer(id.into());
+        Ok(())
+    }
+
     pub fn get_layer(&self, id: impl Into<String>) -> Result<layer::GetLayer> {
         // Notice that in the two examples referenced from: https://docs.mapbox.com/mapbox-gl-js/api/map/#map#getlayer
         // The layer itself is never used. The map.getLayer(id) function is only really used to check if a layer
-        // exists or not. The actual return JsValue from `getLayer` is also basically useless for doing anything
-        // else than that. So for that reason, this function does not return a proper Layer. It's just not parasble.
+        // exists or not. The actual return JsValue from `getLayer` seems basically useless for doing anything
+        // else than that. So for that reason, this function does not return a proper Layer. It's just not parsable.
         let layer = self.inner.getLayer(id.into());
         serde_wasm_bindgen::from_value(layer).map_err(Error::from)
     }
 
+    // #[wasm_bindgen(method)]
+    // pub fn setLayerZoomRange(this: &Map, id: String, min_zoom: f64, max_zoom: f64) -> JsValue;
+
+    // #[wasm_bindgen(method)]
+    // pub fn setFilter(this: &Map, id: String, filter: JsValue, options: JsValue) -> JsValue;
+
+    // #[wasm_bindgen(method)]
+    // pub fn getFilter(this: &Map, id: String) -> JsValue;
+
+    // #[wasm_bindgen(method)]
+    // pub fn setPaintProperty(
+    //     this: &Map,
+    //     id: String,
+    //     name: String,
+    //     value: JsValue,
+    //     options: JsValue,
+    // ) -> JsValue;
     pub fn get_paint_property(
         &self,
         id: impl Into<String>,
@@ -900,6 +944,21 @@ impl Map {
         let expr = self.inner.getPaintProperty(id.into(), name.into());
         serde_wasm_bindgen::from_value(expr).map_err(Error::from)
     }
+
+    // #[wasm_bindgen(method)]
+    // pub fn getPaintProperty(this: &Map, id: String, name: String) -> JsValue;
+
+    // #[wasm_bindgen(method)]
+    // pub fn setLayoutProperty(
+    //     this: &Map,
+    //     id: String,
+    //     name: String,
+    //     value: JsValue,
+    //     options: JsValue,
+    // ) -> JsValue;
+
+    // #[wasm_bindgen(method)]
+    // pub fn getLayoutProperty(this: &Map, id: String, name: String) -> JsValue;
 
     pub fn query_rendered_features<G: IntoQueryGeometry>(
         &self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,6 @@ use serde::{Deserialize, Serialize};
 use std::{
     cell::RefCell,
     collections::HashMap,
-    fmt,
     ops::DerefMut,
     rc::{Rc, Weak},
 };
@@ -671,18 +670,7 @@ pub struct CameraAnimationOptions {
     #[serde(flatten)]
     animation_options: AnimationOptions,
 }
-#[wasm_bindgen]
-extern "C" {
-    // Use `js_namespace` here to bind `console.log(..)` instead of just
-    // `log(..)`
-    #[wasm_bindgen(js_namespace = console)]
-    fn log(s: &str);
-}
-macro_rules! console_log {
-    // Note that this is using the `log` function imported above during
-    // `bare_bones`
-    ($($t:tt)*) => (log(&format_args!($($t)*).to_string()))
-}
+
 impl Map {
     pub fn get_container(&self) -> web_sys::HtmlElement {
         self.inner.getContainer()

--- a/src/marker.rs
+++ b/src/marker.rs
@@ -24,7 +24,6 @@ macro_rules! impl_event_marker {
     ($m: ident, $f:ident, $event:ident, JsValue) => {
         Closure::new(enclose!(
             ($m, $f) move |value: JsValue| {
-                web_sys::console::debug_2(&JsValue::from(stringify!($event)), &value);
                 let Some(marker) = $m.upgrade() else {
                     warn!("Failed to get a marker handle");
                     return;

--- a/src/style.rs
+++ b/src/style.rs
@@ -125,6 +125,8 @@ impl FromWasmAbi for Source {
     }
 }
 
+use crate::layer::Layer;
+
 #[derive(Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct StyleOptions {
@@ -138,4 +140,50 @@ impl StyleOptions {
     pub fn new() -> StyleOptions {
         StyleOptions::default()
     }
+}
+
+#[derive(Deserialize, Debug)]
+pub struct MapboxSdkSupport {
+    pub js: Option<String>,
+    pub android: Option<String>,
+    pub ios: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Metadata {
+    #[serde(rename = "mapbox:origin")]
+    pub mapbox_origin: Option<String>,
+    #[serde(rename = "mapbox:autocomposite")]
+    pub mapbox_autocomposite: Option<bool>,
+    #[serde(rename = "mapbox:type")]
+    pub mapbox_type: Option<String>,
+    #[serde(rename = "mapbox:sdk-support")]
+    pub mapbox_sdk_support: Option<MapboxSdkSupport>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Source {
+    pub url: Option<String>,
+    #[serde(rename = "type")]
+    pub source_type: Option<String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct Style {
+    pub version: Option<u32>,
+    pub name: Option<String>,
+    pub metadata: Option<Metadata>,
+    pub center: Option<Vec<f64>>,
+    pub zoom: Option<f64>,
+    pub bearing: Option<f64>,
+    pub pitch: Option<f64>,
+    pub sprite: Option<String>,
+    pub glyphs: Option<String>,
+    pub layers: Option<Vec<Layer>>,
+    pub created: Option<String>,
+    pub id: Option<String>,
+    pub modified: Option<String>,
+    pub owner: Option<String>,
+    pub visibility: Option<String>,
+    pub draft: Option<bool>,
 }

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,4 +1,4 @@
-use crate::Layer;
+use crate::layer::Layer;
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -49,11 +49,39 @@ impl FromWasmAbi for StyleOrRef {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Style {
     pub version: u32,
     pub sources: Sources,
     pub layers: Vec<Layer>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sprite: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub glyphs: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Metadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub center: Option<Vec<f64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub zoom: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bearing: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pitch: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub created: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub modified: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub visibility: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub draft: Option<bool>,
     // TODO: flesh out optional properties of Style spec
     //       see https://docs.mapbox.com/style-spec/reference/root
 }
@@ -91,10 +119,13 @@ impl FromWasmAbi for Style {
 
 pub type Sources = HashMap<String, Source>;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Source {
     pub r#type: String,
-    pub tiles: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tiles: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
 }
 
 impl From<Source> for JsValue {
@@ -125,8 +156,6 @@ impl FromWasmAbi for Source {
     }
 }
 
-use crate::layer::Layer;
-
 #[derive(Serialize, Deserialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct StyleOptions {
@@ -142,14 +171,14 @@ impl StyleOptions {
     }
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct MapboxSdkSupport {
     pub js: Option<String>,
     pub android: Option<String>,
     pub ios: Option<String>,
 }
 
-#[derive(Deserialize, Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Metadata {
     #[serde(rename = "mapbox:origin")]
     pub mapbox_origin: Option<String>,
@@ -159,31 +188,4 @@ pub struct Metadata {
     pub mapbox_type: Option<String>,
     #[serde(rename = "mapbox:sdk-support")]
     pub mapbox_sdk_support: Option<MapboxSdkSupport>,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct Source {
-    pub url: Option<String>,
-    #[serde(rename = "type")]
-    pub source_type: Option<String>,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct Style {
-    pub version: Option<u32>,
-    pub name: Option<String>,
-    pub metadata: Option<Metadata>,
-    pub center: Option<Vec<f64>>,
-    pub zoom: Option<f64>,
-    pub bearing: Option<f64>,
-    pub pitch: Option<f64>,
-    pub sprite: Option<String>,
-    pub glyphs: Option<String>,
-    pub layers: Option<Vec<Layer>>,
-    pub created: Option<String>,
-    pub id: Option<String>,
-    pub modified: Option<String>,
-    pub owner: Option<String>,
-    pub visibility: Option<String>,
-    pub draft: Option<bool>,
 }


### PR DESCRIPTION
This PR adds most layer methods defined here:
https://docs.mapbox.com/mapbox-gl-js/api/map/#instance-members-layers

And it adds types for all the layers, paint properties and layout properties defined here:
https://docs.mapbox.com/style-spec/reference/layers/

---

Hello hello, [I'm back](https://github.com/yukinarit/mapbox-gl-rs/pull/62) with a huge PR this time. I started using this crate to prototype some shader stuff and I got completely carried away honestly.. So uhm.. I know it's poor form to launch giant PR's like this one at an open source project :sweat_smile: very sorry about that!

I'm putting this PR in draft mode because I think we need to discuss a bunch of things if you are to consider merging it. I hope you can find some time to engage! ~~I cleaned up the work here just a little bit and divided it into 3 commits.~~

~~- One that is pure admin crap to get examples running (deleting and changing Cargo.toml's and Trunk.toml files).~~
~~- Than a commit with a complete refactoring of the layer's and a bunch of other changes sprinkled in, if we actually get to the point where we think the work is worth merging I will obviously clean this up much more.~~
~~- And the final commit contains example updates.~~
This PR is now gated behind: https://github.com/yukinarit/mapbox-gl-rs/pull/65 that basically gets all the examples running again some of which were broken. It also fixes other minor issues I ran into along the way.

The main attraction is basically support for custom webgl layers and strongly typed layout and paint objects. Take a quick look at this screen cap for the coolness of the strong typing! autocomplete!

![demo](https://github.com/yukinarit/mapbox-gl-rs/assets/13096654/7de4dc75-9206-4596-bfcb-055ae7baae90)
