### PR TITLE
feat(map): add `interactive` property to `MapOptions` and builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,79 @@
-target
-Cargo.lock
+# -------------------------------------------------------------------------------------------------
+# Rust
+# -------------------------------------------------------------------------------------------------
+# Generated artifacts
+/target/
+/**/*.rs.bk
+.direnv
+
+# If using Cargo workspaces, ignore lock files at the workspace root, but not sub-crates
+# (uncomment if your project is a single package without multiple crates)
+# /Cargo.lock
+
+# Build scripts
+/build/
+.cache
+/**/.cache
+
+# By default, build scripts output to OUT_DIR, which we don't want in version control
+# (But if you have custom scripts or build output to store, adjust as needed)
+
+# -------------------------------------------------------------------------------------------------
+# IDE / Editor
+# -------------------------------------------------------------------------------------------------
+# Visual Studio Code
+/.vscode/
+/.vscode/
+/*.code-workspace
+
+# IntelliJ IDEA / CLion / Rider
+/.idea/
+/.idea/
+/*.iml
+/.idea_modules/
+/*.ipr
+/*.iws
+out/
+
+# Eclipse
+/.settings/
+/.project
+/.metadata
+/.recommenders
+
+# JetBrains cache
+/.cache/
+
+# Code blocks
+/*.cbp
+/*.depend
+/*.layout
+
+# Rust specific editor backups
+*.swp
+*.swo
+
+# -------------------------------------------------------------------------------------------------
+# Operating System
+# -------------------------------------------------------------------------------------------------
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Linux
+*~
+
+# -------------------------------------------------------------------------------------------------
+# Misc
+# -------------------------------------------------------------------------------------------------
+# Node modules (if any JS or front-end build present)
+node_modules/
+
+# End of file
+/public/cache/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,8 @@ pub struct MapOptions {
     test_mode: Option<bool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     zoom: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    interactive: Option<bool>,
 }
 
 #[wasm_bindgen]
@@ -284,6 +286,7 @@ impl MapOptions {
             scroll_zoom: None,
             test_mode: None,
             zoom: None,
+            interactive: None,
         }
     }
 
@@ -309,6 +312,11 @@ impl MapOptions {
 
     pub fn zoom(mut self, zoom: f64) -> MapOptions {
         self.zoom = Some(zoom);
+        self
+    }
+
+    pub fn interactive(mut self, interactive: bool) -> MapOptions {
+        self.interactive = Some(interactive);
         self
     }
 


### PR DESCRIPTION
### Description
This PR introduces an optional `interactive` property to the `MapOptions` struct and a corresponding builder method `interactive(bool)`. This allows users to configure whether the map should be interactive or not during initialization.

### Changes
- Added `interactive: Option<bool>` in `MapOptions`.
- Created `fn interactive(mut self, interactive: bool) -> MapOptions` builder method.
- Ensured property is skipped during serialization if not set.

### Testing
- Verified setting `interactive(false)` disables user interaction.
- Confirmed omitting the property maintains current behavior (defaults to `true` in Mapbox GL JS).

### Checklist
- [x] Tested locally
