### PR TITLE
Modernize GitHub Actions workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,18 +4,18 @@ on:
   release:
     types: [released]
 
+env:
+  CARGO_TERM_COLOR: always
+
 jobs:
   publish:
     name: publish
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Set up Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
       - name: Login
-        uses: actions-rs/cargo@v1
-        with:
-          command: login
-          args: ${{ secrets.CRATES_IO_API_TOKEN }}
+        run: cargo login ${{ secrets.CRATES_IO_API_TOKEN }}
       - name: Publish
-        uses: actions-rs/cargo@v1
-        with:
-          command: publish
+        run: cargo publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   MAPBOX_TOKEN: token
+  CARGO_TERM_COLOR: always
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,12 +21,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Rust toolchain
-      run: |
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- \
-          --default-toolchain stable \
-          --profile minimal \
-          --component rustfmt clippy \
-          -y
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt, clippy
     - name: Build crate and examples
       run: |
         cargo build --workspace --all-targets --all-features


### PR DESCRIPTION
- Replace manual rustup installation with dtolnay/rust-toolchain@stable
- Replace deprecated actions-rs/cargo with direct cargo commands
- Add CARGO_TERM_COLOR: always for colored CI output
- Add rustfmt and clippy components to toolchain setup

🤖 Generated with [Claude Code](https://claude.ai/code)