### PR TITLE
examples/leptos-simple: Update leptos to 0.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 
 # If using Cargo workspaces, ignore lock files at the workspace root, but not sub-crates
 # (uncomment if your project is a single package without multiple crates)
-# /Cargo.lock
+/Cargo.lock
 
 # Build scripts
 /build/

--- a/examples/leptos-simple/Cargo.toml
+++ b/examples/leptos-simple/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2021"
 
 [dependencies]
 mapboxgl = { path = "../../" }
-leptos = { version = "0.6.11", features = ["csr"] }
+leptos = { version = "0.8.3", features = ["csr"] }

--- a/examples/leptos-simple/src/main.rs
+++ b/examples/leptos-simple/src/main.rs
@@ -1,28 +1,28 @@
-use leptos::*;
+use leptos::{html, prelude::*};
+
 use mapboxgl::{LngLat, Map, MapOptions};
 
 pub fn main() {
-    leptos::mount_to_body(|| view! { <MapComponent/> });
+    leptos::mount::mount_to_body(|| view! { <MapComponent/> });
 }
 
 #[component]
 fn MapComponent() -> impl IntoView {
     // Make a signal that can store the map inside the reactive system..
     // The map has to _live_ for it to be able track its handlers and stuff!
-    let map_store = create_rw_signal(None);
-    let map_ref = create_node_ref::<html::Div>();
-    map_ref.on_load(move |m| {
-        let _map_el = m.on_mount(move |map| {
-            let token = std::env::var("MAPBOX_TOKEN").unwrap_or_else(|_| "your_token_here".to_string());
-            let map = Map::new(
-                MapOptions::new(token, map.get_attribute("id").unwrap())
-                    .center(LngLat::new(10.7, 59.9))
-                    .zoom(12.0),
-            )
-            .unwrap();
-            // Persist the map into the reactive system
-            map_store.set(Some(map));
-        });
+    let map_store = RwSignal::new_local(None);
+
+    let map_ref = NodeRef::<html::Div>::new();
+    map_ref.on_load(move |div_element| {
+        let token = std::env::var("MAPBOX_TOKEN").unwrap_or_else(|_| "your_token_here".to_string());
+        let map = Map::new(
+            MapOptions::new(token, div_element.get_attribute("id").unwrap())
+                .center(LngLat::new(10.7, 59.9))
+                .zoom(12.0),
+        )
+        .unwrap();
+        // Persist the map into the reactive system
+        map_store.set(Some(map));
     });
     view! {<div id="map" style="position: absolute; top: 0; bottom: 0; width: 100%;" node_ref=map_ref/>}
 }


### PR DESCRIPTION
This updates the leptos dependency in the respective example to the latest 0.8 version, and adjusts the code accordingly.